### PR TITLE
Zendesk chat engagements table

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,9 +94,11 @@ ENV/
 
 # Custom stuff
 env.sh
+state.json
 config.json
 .autoenv.zsh
 
 rsa-key
 tags
 properties.json
+catalog.json

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(name="tap-zendesk-chat",
       install_requires=[
           "python-dateutil==2.6.0",  # because of singer-python issue
           "pendulum==1.2.0",  # because of singer-python issue
-          "singer-python==3.5.0",
+          "singer-python==5.7.1",
           "requests==2.20.0",
       ],
       entry_points="""

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(name="tap-zendesk-chat",
       install_requires=[
           "python-dateutil==2.6.0",  # because of singer-python issue
           "pendulum==1.2.0",  # because of singer-python issue
-          "singer-python==5.7.1",
+          "singer-python==5.7.*",
           "requests==2.20.0",
       ],
       entry_points="""

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 from setuptools import setup, find_packages
 
 setup(name="tap-zendesk-chat",
-      version="0.1.20-engagements",
+      version="0.2.0",
       description="Singer.io tap for extracting data from the Zendesk Chat API",
       author="Stitch",
       url="http://singer.io",

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 from setuptools import setup, find_packages
 
 setup(name="tap-zendesk-chat",
-      version="0.1.18",
+      version="0.1.19",
       description="Singer.io tap for extracting data from the Zendesk Chat API",
       author="Stitch",
       url="http://singer.io",

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 from setuptools import setup, find_packages
 
 setup(name="tap-zendesk-chat",
-      version="0.1.19",
+      version="0.1.19-engagements",
       description="Singer.io tap for extracting data from the Zendesk Chat API",
       author="Stitch",
       url="http://singer.io",

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 from setuptools import setup, find_packages
 
 setup(name="tap-zendesk-chat",
-      version="0.1.19-engagements",
+      version="0.1.20-engagements",
       description="Singer.io tap for extracting data from the Zendesk Chat API",
       author="Stitch",
       url="http://singer.io",

--- a/tap_zendesk_chat/__init__.py
+++ b/tap_zendesk_chat/__init__.py
@@ -85,8 +85,11 @@ def sync(ctx):
     streams = [s for s in streams_.all_streams[start_idx:]
                if s.tap_stream_id in stream_ids_to_sync]
     for stream in streams:
-        ctx.state["currently_syncing"] = stream.tap_stream_id
+        # Output schemas of all streams to start so that we can output
+        # records of any type when needed.
         output_schema(stream)
+    for stream in streams:
+        ctx.state["currently_syncing"] = stream.tap_stream_id
         ctx.write_state()
         stream.sync(ctx)
     ctx.state["currently_syncing"] = None

--- a/tap_zendesk_chat/discover.py
+++ b/tap_zendesk_chat/discover.py
@@ -1,0 +1,18 @@
+import os
+import json
+import singer
+
+from .util import get_abs_path
+
+
+def discover_streams(all_streams):
+    streams = []
+    for s in all_streams:
+        schema = singer.resolve_schema_references(s.load_schema())
+        streams.append({
+            'stream': s.tap_stream_id,
+            'tap_stream_id': s.tap_stream_id,
+            'schema': schema,
+            'metadata': s.load_metadata()
+        })
+    return streams

--- a/tap_zendesk_chat/http.py
+++ b/tap_zendesk_chat/http.py
@@ -37,7 +37,7 @@ class Client(object):
         try:
             response.raise_for_status()
         except:
-            LOGGER.exception(response.content!r)
+            LOGGER.exception(response.content)
             raise
         return response.json()
 

--- a/tap_zendesk_chat/schemas/chats.json
+++ b/tap_zendesk_chat/schemas/chats.json
@@ -1,204 +1,240 @@
 {
-  "properties": {
-    "department_id": {
-      "type": [
+    "properties": {
+        "department_id": {
+            "type": [
+                "null",
+                "integer"
+            ]
+        },
+        "comment": {
+            "type": [
+                "null",
+                "string"
+            ]
+        },
+        "missed": {
+            "type": [
+                "null",
+                "boolean"
+            ]
+        },
+        "rating": {
+            "type": [
+                "null",
+                "string"
+            ]
+        },
+        "conversions": {
+            "items": {
+                "$ref": "chat_conversion"
+            },
+            "type": [
+                "null",
+                "array"
+            ]
+        },
+        "type": {
+            "type": [
+                "null",
+                "string"
+            ]
+        },
+        "webpath": {
+            "items": {
+                "$ref": "chat_webpath"
+            },
+            "type": [
+                "null",
+                "array"
+            ]
+        },
+        "triggered": {
+            "type": [
+                "null",
+                "boolean"
+            ]
+        },
+        "message": {
+            "type": [
+                "null",
+                "string"
+            ]
+        },
+        "referrer_search_terms": {
+            "type": [
+                "null",
+                "string"
+            ]
+        },
+        "referrer_search_engine": {
+            "type": [
+                "null",
+                "string"
+            ]
+        },
+        "zendesk_ticket_id": {
+            "type": [
+                "null",
+                "integer"
+            ]
+        },
+        "unread": {
+            "type": [
+                "null",
+                "boolean",
+                "integer"
+            ]
+        },
+        "timestamp": {
+            "type": [
+                "null",
+                "string"
+            ],
+            "format": "date-time"
+        },
+        "end_timestamp": {
+            "type": [
+                "null",
+                "string"
+            ],
+            "format": "date-time"
+        },
+        "response_time": {
+            "$ref": "chat_response_time"
+        },
+        "session": {
+            "type": [
+                "null",
+                "object"
+            ],
+            "additionalProperties": true
+        },
+        "history": {
+            "items": {
+                "$ref": "chat_history"
+            },
+            "type": [
+                "null",
+                "array"
+            ]
+        },
+        "agent_names": {
+            "items": {
+                "type": [
+                    "string"
+                ]
+            },
+            "type": [
+                "null",
+                "array"
+            ]
+        },
+        "tags": {
+            "items": {
+                "type": [
+                    "string"
+                ]
+            },
+            "type": [
+                "null",
+                "array"
+            ]
+        },
+        "visitor": {
+            "$ref": "chat_visitor"
+        },
+        "started_by": {
+            "type": [
+                "null",
+                "string"
+            ]
+        },
+        "triggered_response": {
+            "type": [
+                "null",
+                "boolean"
+            ]
+        },
+        "id": {
+            "type": [
+                "null",
+                "string"
+            ]
+        },
+        "count": {
+            "$ref": "chat_count"
+        },
+        "agent_ids": {
+            "items": {
+                "type": [
+                    "string"
+                ]
+            },
+            "type": [
+                "null",
+                "array"
+            ]
+        },
+        "department_name": {
+            "type": [
+                "null",
+                "string"
+            ]
+        },
+        "duration": {
+            "type": [
+                "null",
+                "integer"
+            ]
+        },
+        "update_timestamp": {
+            "type": [
+                "string"
+            ],
+            "format": "date-time"
+        },
+        "skills_requested": {
+            "type": [
+                "object"
+            ]
+        },
+        "skills_fulfilled": {
+            "type": [
+                "boolean"
+            ]
+        },
+        "abandon_time": {
+            "type": [
+                "number"
+            ]
+        },
+        "dropped": {
+            "type": [
+                "boolean"
+            ]
+        },
+        "proactive": {
+            "type": [
+                "boolean"
+            ]
+        },
+        "deleted": {
+            "type": [
+                "boolean"
+            ]
+        }
+    },
+    "additionalProperties": false,
+    "type": [
         "null",
-        "integer"
-      ]
-    },
-    "comment": {
-      "type": [
-        "null",
-        "string"
-      ]
-    },
-    "missed": {
-      "type": [
-        "null",
-        "boolean"
-      ]
-    },
-    "rating": {
-      "type": [
-        "null",
-        "string"
-      ]
-    },
-    "conversions": {
-      "items": {
-        "$ref": "chat_conversion"
-      },
-      "type": [
-        "null",
-        "array"
-      ]
-    },
-    "type": {
-      "type": [
-        "null",
-        "string"
-      ]
-    },
-    "webpath": {
-      "items": {
-        "$ref": "chat_webpath"
-      },
-      "type": [
-        "null",
-        "array"
-      ]
-    },
-    "triggered": {
-      "type": [
-        "null",
-        "boolean"
-      ]
-    },
-    "message": {
-      "type": [
-        "null",
-        "string"
-      ]
-    },
-    "referrer_search_terms": {
-      "type": [
-        "null",
-        "string"
-      ]
-    },
-    "referrer_search_engine": {
-      "type": [
-        "null",
-        "string"
-      ]
-    },
-    "zendesk_ticket_id": {
-      "type": [
-        "null",
-        "integer"
-      ]
-    },
-    "unread": {
-      "type": [
-        "null",
-        "boolean",
-        "integer"
-      ]
-    },
-    "timestamp": {
-      "type": [
-        "null",
-        "string"
-      ],
-      "format": "date-time"
-    },
-    "end_timestamp": {
-      "type": [
-        "null",
-        "string"
-      ],
-      "format": "date-time"
-    },
-    "response_time": {
-      "$ref": "chat_response_time"
-    },
-    "session": {
-        "type": [
-          "null",
-          "object"
-        ],
-        "additionalProperties": true
-    },
-    "history": {
-      "items": {
-        "$ref": "chat_history"
-      },
-      "type": [
-        "null",
-        "array"
-      ]
-    },
-    "agent_names": {
-      "items": {
-        "type": [
-          "string"
-        ]
-      },
-      "type": [
-        "null",
-        "array"
-      ]
-    },
-    "tags": {
-      "items": {
-        "type": [
-          "string"
-        ]
-      },
-      "type": [
-        "null",
-        "array"
-      ]
-    },
-    "visitor": {
-      "$ref": "chat_visitor"
-    },
-    "started_by": {
-      "type": [
-        "null",
-        "string"
-      ]
-    },
-    "triggered_response": {
-      "type": [
-        "null",
-        "boolean"
-      ]
-    },
-    "id": {
-      "type": [
-        "null",
-        "string"
-      ]
-    },
-    "count": {
-      "$ref": "chat_count"
-    },
-    "agent_ids": {
-      "items": {
-        "type": [
-          "string"
-        ]
-      },
-      "type": [
-        "null",
-        "array"
-      ]
-    },
-    "department_name": {
-      "type": [
-        "null",
-        "string"
-      ]
-    },
-    "duration": {
-      "type": [
-        "null",
-        "integer"
-      ]
-    }
-  },
-  "additionalProperties": false,
-  "type": [
-    "null",
-    "object"
-  ],
-  "tap_schema_dependencies": [
-    "chat_conversion",
-    "chat_count",
-    "chat_history",
-    "chat_response_time",
-    "chat_visitor",
-    "chat_webpath"
-  ]
+        "object"
+    ],
+    "tap_schema_dependencies": [
+        "chat_conversion",
+        "chat_count",
+        "chat_history",
+        "chat_response_time",
+        "chat_visitor",
+        "chat_webpath"
+    ]
 }

--- a/tap_zendesk_chat/schemas/chats.json
+++ b/tap_zendesk_chat/schemas/chats.json
@@ -189,42 +189,49 @@
         },
         "update_timestamp": {
             "type": [
+                "null",
                 "string"
             ],
             "format": "date-time"
         },
         "skills_requested": {
             "type": [
-                "object"
+                "null",
+                "array"
             ]
         },
         "skills_fulfilled": {
             "type": [
+                "null",
                 "boolean"
             ]
         },
         "abandon_time": {
             "type": [
+                "null",
                 "number"
             ]
         },
         "dropped": {
             "type": [
+                "null",
                 "boolean"
             ]
         },
         "proactive": {
             "type": [
+                "null",
                 "boolean"
             ]
         },
         "deleted": {
             "type": [
+                "null",
                 "boolean"
             ]
         }
     },
-    "additionalProperties": false,
+    "additionalProperties": true,
     "type": [
         "null",
         "object"

--- a/tap_zendesk_chat/schemas/engagements.json
+++ b/tap_zendesk_chat/schemas/engagements.json
@@ -19,7 +19,8 @@
         "agent_id": {
             "type": [
                 "null",
-                "integer"
+                "integer",
+                "string"
             ]
         },
         "agent_full_name": {
@@ -28,10 +29,17 @@
                 "string"
             ]
         },
+        "agent_name": {
+            "type": [
+                "null",
+                "string"
+            ]
+        },
         "department_id": {
             "type": [
                 "null",
-                "integer"
+                "integer",
+                "string"
             ]
         },
         "assigned": {
@@ -96,7 +104,7 @@
             ]
         }
     },
-    "additionalProperties": false,
+    "additionalProperties": true,
     "type": [
         "null",
         "object"

--- a/tap_zendesk_chat/schemas/engagements.json
+++ b/tap_zendesk_chat/schemas/engagements.json
@@ -1,0 +1,107 @@
+{
+    "properties": {
+        "id": {
+            "type": [
+                "string"
+            ]
+        },
+        "chat_id": {
+            "type": [
+                "string"
+            ]
+        },
+        "started_by": {
+            "type": [
+                "null",
+                "string"
+            ]
+        },
+        "agent_id": {
+            "type": [
+                "null",
+                "integer"
+            ]
+        },
+        "agent_full_name": {
+            "type": [
+                "null",
+                "string"
+            ]
+        },
+        "department_id": {
+            "type": [
+                "null",
+                "integer"
+            ]
+        },
+        "assigned": {
+            "type": [
+                "null",
+                "boolean"
+            ]
+        },
+        "accepted": {
+            "type": [
+                "null",
+                "boolean"
+            ]
+        },
+        "rating": {
+            "type": [
+                "null",
+                "string"
+            ]
+        },
+        "comment": {
+            "type": [
+                "null",
+                "string"
+            ]
+        },
+        "skills_requested": {
+            "type": [
+                "null",
+                "array"
+            ]
+        },
+        "skills_fulfilled": {
+            "type": [
+                "null",
+                "boolean"
+            ]
+        },
+        "timestamp": {
+            "type": [
+                "null",
+                "string"
+            ],
+            "format": "date-time"
+        },
+        "duration": {
+            "type": [
+                "null",
+                "number"
+            ]
+        },
+        "response_time": {
+            "type": [
+                "null",
+                "object"
+            ]
+        },
+        "count": {
+            "type": [
+                "null",
+                "object"
+            ]
+        }
+    },
+    "additionalProperties": false,
+    "type": [
+        "null",
+        "object"
+    ],
+    "tap_schema_dependencies": [
+        "chats"
+    ]
+}

--- a/tap_zendesk_chat/streams.py
+++ b/tap_zendesk_chat/streams.py
@@ -207,13 +207,13 @@ class Chats(Stream):
         """
         pull_id = uuid.uuid4()
 
-        chats = self.SubStream(
+        chats_stream = self.SubStream(
             ctx=ctx, tap_stream_id=self.tap_stream_id, chat_type='chat',
             ts_field='end_timestamp')
-        offline_msgs = self.SubStream(
+        offline_msgs_stream = self.SubStream(
             ctx=ctx, tap_stream_id=self.tap_stream_id, chat_type='offline_msg',
             ts_field='timestamp')
-        substreams = [chats, offline_msgs]
+        substreams = [chats_stream, offline_msgs_stream]
 
         url_offset_key = [self.tap_stream_id, "offset", "chats-incremental.next_url"]
         ts_bookmark_key = [self.tap_stream_id, "chats-incremental.end_time"]

--- a/tap_zendesk_chat/streams.py
+++ b/tap_zendesk_chat/streams.py
@@ -160,6 +160,16 @@ class Chats(Stream):
 
         The overall affect here is if we are consistently getting too few
         records, we give up and pick up the task later.
+
+        NOTE: (PH) The way we are determining when we can fetch data right away
+        and when we should wait to fetch data is at odds with the incremental
+        api's documentation (which says when you get fewer than `limit`
+        records, you should fetch without waiting, and if you have exactly
+        `limit` records, you should wait). That advice doesn't make much
+        sense to me and doesn't seem to match my observations of how their
+        api works. What seems to happen is you get `limit` items until we
+        reach the most recent records, at which point they trickle in. This
+        method attempts to detect when it starts to trickle.
         """
 
         # If the average record count for the last

--- a/tap_zendesk_chat/streams.py
+++ b/tap_zendesk_chat/streams.py
@@ -263,6 +263,8 @@ class Chats(Stream):
             for chat in chats:
                 engagements_data = chat.pop('engagements', None)
                 if engagements and engagements_data:
+                    for engagement in engagements_data:
+                        engagement['chat_id'] = chat['id']
                     engagements.sync(ctx, engagements_data)
 
             self.write_page(chats)

--- a/tap_zendesk_chat/streams.py
+++ b/tap_zendesk_chat/streams.py
@@ -11,6 +11,16 @@ LOGGER = singer.get_logger()
 
 
 def clamp(min_val, val, max_val):
+    """
+    Clamp a number within a range
+
+    >>> clamp(0, 0.5, 1)
+    0.5
+    >>> clamp(0, -1, 1)
+    0
+    >>> clamp(0, 10, 1)
+    1
+    """
     return min(max_val, max(min_val, val))
 
 
@@ -88,7 +98,8 @@ class Agents(Stream):
 class Engagements(Stream):
     def sync(self, ctx, engagements=None):
         if not engagements:
-            LOGGER.warning('Engagements is called as a part of the Chat stream rather than directly')
+            # __init__.py calls sync on all streams, but this one is handled
+            # within the Chats stream, so ignore this call.
             return
         self.write_page(engagements)
 

--- a/tap_zendesk_chat/streams.py
+++ b/tap_zendesk_chat/streams.py
@@ -1,12 +1,17 @@
 from datetime import datetime, timedelta
 from pendulum import parse as dt_parse
 from singer import metrics
+import dataclasses
 import json
 import singer
 import time
 import uuid
 
 LOGGER = singer.get_logger()
+
+
+def clamp(min_val, val, max_val):
+    return min(max_val, max(min_val, val))
 
 
 def break_into_intervals(days, hours, start_time: str, now: datetime):
@@ -76,71 +81,167 @@ class Agents(Stream):
 
 
 class Chats(Stream):
-    def _bulk_chats(self, ctx, chat_ids):
-        if not chat_ids:
-            return []
-        params = {"ids": ",".join(chat_ids)}
-        body = ctx.client.request(self.tap_stream_id, params=params)
-        return list(body["docs"].values())
+    LIMIT = 1000
+    # How long to wait for more records in seconds
+    WAIT_TIME = 60
 
-    def _search(self, ctx, chat_type, ts_field,
-                start_dt: datetime, end_dt: datetime):
+    def _request(self, ctx, *args, **kwargs):
+        return ctx.client.incremental_request(self.tap_stream_id, *args, **kwargs)
+
+    def _start_request(self, ctx, start_dt: datetime):
         params = {
-            "q": "type:{} AND {}:[{} TO {}]"
-            .format(chat_type, ts_field, start_dt.isoformat(), end_dt.isoformat())
+            "start_time": int(start_dt.timestamp()),
+            "limit": self.LIMIT,
+            "fields": "chats(*)",
         }
-        return ctx.client.request(
-            self.tap_stream_id, params=params, url_extra="/search")
+        return self._request(ctx, params=params)
 
-    def _pull(self, ctx, chat_type, ts_field, *, full_sync):
-        """Pulls and writes pages of data for the given chat_type, where
-        chat_type can be either "chat" or "offline_msg".
+    @dataclasses.dataclass
+    class SubStream:
+        """
+        Since _sync actually has to manage two different object types
+        (chat and offline_msg objects), create a small dataclass to store
+        the state for each one (and perform stateful operations on that state).
+        """
 
-        ts_field determines the property of the chat objects that is used as
-        the bookmark for the chat.
+        tap_stream_id: str
+        chat_type: str
+        ts_field: str
+        ctx: 'Context'
+        start_time: datetime = None
+        buf: list = dataclasses.field(default_factory=list)
+
+        @property
+        def ts_bookmark_key(self):
+            return [self.tap_stream_id, self.chat_type + "." + self.ts_field]
+
+        def update_start_date_bookmark(self):
+            start_time = self.ctx.update_start_date_bookmark(self.ts_bookmark_key)
+            self.start_time = dt_parse(start_time)
+            return self.start_time
+
+        def set_ts_bookmark(self, ts_bookmark):
+            self.ctx.set_bookmark(self.ts_bookmark_key, ts_bookmark)
+
+        def write_page(self, parent_stream, ts_bookmark):
+            """
+            Writes buf to page and updates the timestamp bookmark if the
+            length of buf >= buffer_size or force is True. Returns whether
+            it wrote the page.
+            """
+            if self.buf:
+                # Don't bother writing an empty buffer (even if force is True)
+                parent_stream.write_page(self.buf)
+                self.buf = []
+            self.set_ts_bookmark(ts_bookmark)
+
+    def should_give_up(self, pull_id, ctx, record_counts):
+        """
+        Determine if it's time to give up making requests because the results
+        are petering out. This is needed because zendesk chat's incremental
+        api is strange and it doesn't tell you when it's done.
+
+        The overall affect here is if we are consistently getting too few
+        records, we give up and pick up the task later.
+        """
+
+        # If the average record count for the last
+        # `incremental_give_up_num_requests` is < `incremental_give_up_ratio`
+        # * self.LIMIT, then we give up for now.
+        give_up_ratio = clamp(
+            0, ctx.config.get('incremental_give_up_ratio', 0.05), 1)
+        give_up_num_requests = ctx.config.get('incremental_give_up_num_requests', 5)
+
+        if len(record_counts) < give_up_num_requests:
+            return False
+        # Truncate list to get rid of values we will no longer use.
+        while len(record_counts) > give_up_num_requests:
+            record_counts.pop(0)
+
+        give_up_threshold = self.LIMIT * give_up_ratio
+        avg_counts = sum(record_counts) / len(record_counts)
+        give_up = give_up_threshold > avg_counts
+        LOGGER.info(
+            '%s: give_up_threshold=%s, avg_counts=%s, give_up=%s',
+            pull_id, give_up_threshold, avg_counts, give_up)
+        return give_up
+
+    def _sync(self, ctx, *, full_sync):
+        """
+        Pulls data from the incremental chats api and manage sending the
+        offline messages to the offline_msg stream and the chat messages to
+        the chat stream.
 
         full_sync is a boolean indicating whether or not to pull all chats
         based on the "start_date" in the config. When this is true, all
         bookmarks for this chat type will be ignored.
+
+        TODO add a way to sync engagements as well.
         """
         pull_id = uuid.uuid4()
 
-        ts_bookmark_key = [self.tap_stream_id, chat_type + "." + ts_field]
-        url_offset_key = [self.tap_stream_id, "offset", chat_type + ".next_url"]
+        chats = self.SubStream(
+            ctx=ctx, tap_stream_id=self.tap_stream_id, chat_type='chat',
+            ts_field='end_timestamp')
+        offline_msgs = self.SubStream(
+            ctx=ctx, tap_stream_id=self.tap_stream_id, chat_type='offline_msg',
+            ts_field='timestamp')
+        substreams = [chats, offline_msgs]
+
+        url_offset_key = [self.tap_stream_id, "offset", "chats-incremental.next_url"]
+
         if full_sync:
-            ctx.set_bookmark(ts_bookmark_key, None)
-            ctx.set_bookmark(url_offset_key, None)
-        start_time = ctx.update_start_date_bookmark(ts_bookmark_key)
-        next_url = ctx.bookmark(url_offset_key)
+            for stream in substreams:
+                stream.set_ts_bookmark(None)
+        for stream in substreams:
+            stream.update_start_date_bookmark()
+        start_time = min(s.start_time for s in substreams)
         max_bookmark = start_time
 
-        interval_days = 0
-        interval_days_str = ctx.config.get("chat_search_interval_days")
-        if interval_days_str is not None:
-            interval_days = float(interval_days_str)
-        LOGGER.info("{} Begin syncing using chat_search_interval_days: {}".format(pull_id, interval_days))
+        end_dt = ctx.now
+        # This will be moved forward with each request
+        end_time = start_time
+        log_attrs = ["start_dt=%s" % start_time, "end_dt=%s" % end_dt]
 
-        intervals = break_into_intervals(interval_days, 1, start_time, ctx.now)
-        for start_dt, end_dt in intervals:
-            log_attrs = ["start_dt=%s" % start_dt, "end_dt=%s" % end_dt]
-            while True:
-                if next_url:
-                    search_resp = ctx.client.request(self.tap_stream_id, url=next_url)
+        resp = None
+        next_url = None
+        record_counts = []
+        while end_time < end_dt:
+            if next_url:
+                resp = self._request(ctx, url=next_url)
+            else:
+                resp = self._start_request(ctx, start_time)
+
+            record_counts.append(resp['count'])
+
+            next_url = resp["next_page"]
+            ctx.set_bookmark(url_offset_key, next_url)
+
+            LOGGER.info('{} Request completed: {}'.format(pull_id, ",".join(log_attrs + ['count=%s' % resp['count']])))
+
+            # Allows us to break out of the loop when we go past our desired endpoint
+            end_time = datetime.utcfromtimestamp(resp["end_time"])
+            max_bookmark = max(max_bookmark, end_time)
+
+            for chat in resp['chats']:
+                if chat['type'] == 'chat':
+                    chats.buf.append(chat)
+                elif chat['type'] == 'offline_msg':
+                    offline_msgs.buf.append(chat)
                 else:
-                    search_resp = self._search(ctx, chat_type, ts_field, start_dt, end_dt)
-                next_url = search_resp["next_url"]
-                ctx.set_bookmark(url_offset_key, next_url)
-                ctx.write_state()
-                chat_ids = [r["id"] for r in search_resp["results"]]
-                chats = self._bulk_chats(ctx, chat_ids)
-                if chats:
-                    self.write_page(chats)
-                    max_bookmark = max(max_bookmark, *[c[ts_field] for c in chats])
-                if not next_url:
-                    LOGGER.info('{} Finished syncing: {}'.format(pull_id, ",".join(log_attrs)))
-                    break
-            ctx.set_bookmark(ts_bookmark_key, max_bookmark)
+                    raise NotImplementedError(chat['type'])
+
+            for stream in substreams:
+                stream.write_page(self, max_bookmark)
             ctx.write_state()
+
+            if not next_url:
+                LOGGER.info('{} Finished syncing: {}'.format(pull_id, ",".join(log_attrs)))
+                break
+
+            if self.should_give_up(pull_id, ctx, record_counts):
+                LOGGER.info('{} Got too few results; giving up: {}'.format(pull_id, ",".join(log_attrs)))
+                break
 
     def _should_run_full_sync(self, ctx):
         sync_days = ctx.config.get("chats_full_sync_days")
@@ -159,8 +260,7 @@ class Chats(Stream):
 
     def sync(self, ctx):
         full_sync = self._should_run_full_sync(ctx)
-        self._pull(ctx, "chat", "end_timestamp", full_sync=full_sync),
-        self._pull(ctx, "offline_msg", "timestamp", full_sync=full_sync)
+        self._sync(ctx, full_sync=full_sync)
         if full_sync:
             ctx.state["chats_last_full_sync"] = ctx.now.isoformat()
             ctx.write_state()

--- a/tap_zendesk_chat/util.py
+++ b/tap_zendesk_chat/util.py
@@ -1,0 +1,22 @@
+import os
+
+from singer import utils
+import singer
+
+
+def get_abs_path(path):
+    return os.path.join(os.path.dirname(os.path.realpath(__file__)), path)
+
+
+def load_schema(tap_stream_id):
+    path = "schemas/{}.json".format(tap_stream_id)
+    schema = utils.load_json(get_abs_path(path))
+    dependencies = schema.pop("tap_schema_dependencies", [])
+    refs = {}
+    for sub_stream_id in dependencies:
+        refs[sub_stream_id] = load_schema(sub_stream_id)
+    if refs:
+        singer.resolve_schema_references(schema, refs)
+    return schema
+
+


### PR DESCRIPTION
Switched from search api to incremental api. This should reduce the number of requests overall, and it exposes data we can't get from the search api, namely the engagements data that earnin wants.

The incremental api is pretty strange, so we have to jump through some hoops to decide when we're done fetching data. Right now we will stop fetching in two conditions:

1. If the `end_time` in the latest request is past `ctx.now` (representing when the process started) then we are done
2. If the results start to trickle in (instead of getting full payloads) then we quit and will get more data later (see [`should_give_up`](https://github.com/Pathlight/tap-zendesk-chat/pull/1/files#diff-475d8371397898b8c4ac468aff183963R155)).